### PR TITLE
add lexus_description to build_depends.repos

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/tier4/pilot.auto.git
     version: ros2
+  description/vehicle/lexus_description:
+    type: git
+    url: https://github.com/tier4/lexus_description.iv.universe.git
+    version: ros2
   # dependencies for autoware/pilot.auto
   vendor/grid_map:
     type: git


### PR DESCRIPTION
This adds lexus_description to the build_depends.repos, which should make https://github.com/tier4/planning_simulator.iv.universe/pull/3 to pass CI. 