### PR TITLE
scenario_api_simulator port to ROS2

### DIFF
--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -1,57 +1,51 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(scenario_api_simulator)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  sensor_msgs
-  geometry_msgs
-  std_msgs
-  autoware_planning_msgs
-  autoware_system_msgs
-  autoware_perception_msgs
-  autoware_vehicle_msgs
-  npc_simulator
-  roscpp
-  tf2_ros
-  pcl_ros
-  pcl_conversions
-  lanelet2_extension
-  scenario_api_utils
-)
-
-catkin_package(
- INCLUDE_DIRS include
- LIBRARIES scenario_api_simulator
- CATKIN_DEPENDS scenario_api_utils sensor_msgs geometry_msgs std_msgs autoware_planning_msgs autoware_system_msgs autoware_perception_msgs autoware_vehicle_msgs npc_simulator roscpp tf2_ros pcl_ros pcl_conversions lanelet2_extension
-)
-
-include_directories(
-include
-${catkin_INCLUDE_DIRS}
-)
+find_package(ament_cmake REQUIRED)
+find_package(autoware_lanelet2_msgs REQUIRED)
+find_package(autoware_perception_msgs REQUIRED)
+find_package(dummy_perception_publisher REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(lanelet2_extension REQUIRED)
+find_package(npc_simulator REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(scenario_api_utils REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
 
 add_library(scenario_api_simulator SHARED
-src/scenario_api_simulator.cpp
-src/npc_route_manager.cpp
+  src/scenario_api_simulator.cpp
+  src/npc_route_manager.cpp
+)
+target_include_directories(scenario_api_simulator PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
-add_dependencies(scenario_api_simulator
- ${${PROJECT_NAME}_EXPORTED_TARGETS}
- ${catkin_EXPORTED_TARGETS}
- )
+ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs)
 
-target_link_libraries(scenario_api_simulator
- ${catkin_LIBRARIES}
- ${YAML_CPP_LIBRARIES}
-)
+ament_export_targets(export_scenario_api_simulator HAS_LIBRARY_TARGET)
+ament_export_dependencies(autoware_perception_msgs geometry_msgs npc_simulator rclcpp std_msgs unique_identifier_msgs)
 
 install(TARGETS scenario_api_simulator
-ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  EXPORT export_scenario_api_simulator
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(DIRECTORY include/
+  DESTINATION include
 )
+
+ament_package()

--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -10,17 +10,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(autoware_lanelet2_msgs REQUIRED)
-find_package(autoware_perception_msgs REQUIRED)
-find_package(dummy_perception_publisher REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(lanelet2_extension REQUIRED)
-find_package(npc_simulator REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(scenario_api_utils REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(unique_identifier_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 add_library(scenario_api_simulator SHARED
   src/scenario_api_simulator.cpp

--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-ament_auto_add_library(${PROJECT_NAME} STATIC
+ament_auto_add_library(${PROJECT_NAME}
   src/scenario_api_simulator.cpp
   src/npc_route_manager.cpp
   )

--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(scenario_api_simulator SHARED
+add_library(scenario_api_simulator STATIC
   src/scenario_api_simulator.cpp
   src/npc_route_manager.cpp
 )
@@ -22,7 +22,7 @@ target_include_directories(scenario_api_simulator PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs)
+ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs vehicle_info_util)
 
 ament_export_targets(export_scenario_api_simulator HAS_LIBRARY_TARGET)
 ament_export_dependencies(autoware_perception_msgs geometry_msgs npc_simulator rclcpp std_msgs unique_identifier_msgs)

--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(scenario_api_simulator STATIC
+add_library(scenario_api_simulator SHARED
   src/scenario_api_simulator.cpp
   src/npc_route_manager.cpp
 )
@@ -22,7 +22,7 @@ target_include_directories(scenario_api_simulator PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs vehicle_info_util)
+ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs)
 
 ament_export_targets(export_scenario_api_simulator HAS_LIBRARY_TARGET)
 ament_export_dependencies(autoware_perception_msgs geometry_msgs npc_simulator rclcpp std_msgs unique_identifier_msgs)

--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -4,14 +4,12 @@ project(scenario_api_simulator)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
-
-find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
@@ -20,43 +18,5 @@ ament_auto_add_library(${PROJECT_NAME} STATIC
   src/scenario_api_simulator.cpp
   src/npc_route_manager.cpp
   )
-# add_library(scenario_api_simulator SHARED
-#   src/scenario_api_simulator.cpp
-#   src/npc_route_manager.cpp
-# )
-# target_include_directories(scenario_api_simulator PUBLIC
-#   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-#   $<INSTALL_INTERFACE:include>
-# )
 
-# ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs)
-
-# ament_export_targets(export_scenario_api_simulator HAS_LIBRARY_TARGET)
-# ament_export_dependencies(autoware_perception_msgs geometry_msgs npc_simulator rclcpp std_msgs unique_identifier_msgs)
-
-# install(TARGETS scenario_api_simulator
-#   EXPORT export_scenario_api_simulator
-#   ARCHIVE DESTINATION lib
-#   LIBRARY DESTINATION lib
-#   RUNTIME DESTINATION bin
-#   INCLUDES DESTINATION include
-# )
-
-# install(DIRECTORY include/
-#   DESTINATION include
-# )
-
-ament_package()
-
-message("${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}")
-set(PROJECT_TO_INSPECT npc_simulator)
-message("${PROJECT_TO_INSPECT} variables")
-# message("${${PROJECT_TO_INSPECT}_DEFINITIONS}")
-message("${${PROJECT_TO_INSPECT}_INCLUDE_DIRS}")
-# message("${${PROJECT_TO_INSPECT}_LIBRARIES}")
-# message("${${PROJECT_TO_INSPECT}_LINK_FLAGS}")
-# message("${${PROJECT_TO_INSPECT}_RECURSIVE_DEPENDENCIES}")
-message("targets: ${${PROJECT_TO_INSPECT}_TARGETS}")
-
-get_target_property(_include_dirs ${PROJECT_NAME} INTERFACE_INCLUDE_DIRECTORIES)
-message("${_include_dirs}")
+ament_auto_package()

--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -13,30 +13,50 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(scenario_api_simulator SHARED
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(${PROJECT_NAME} STATIC
   src/scenario_api_simulator.cpp
   src/npc_route_manager.cpp
-)
-target_include_directories(scenario_api_simulator PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
+  )
+# add_library(scenario_api_simulator SHARED
+#   src/scenario_api_simulator.cpp
+#   src/npc_route_manager.cpp
+# )
+# target_include_directories(scenario_api_simulator PUBLIC
+#   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+#   $<INSTALL_INTERFACE:include>
+# )
 
-ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs)
+# ament_target_dependencies(scenario_api_simulator autoware_perception_msgs dummy_perception_publisher geometry_msgs lanelet2_extension npc_simulator rclcpp scenario_api_utils std_msgs tf2 unique_identifier_msgs)
 
-ament_export_targets(export_scenario_api_simulator HAS_LIBRARY_TARGET)
-ament_export_dependencies(autoware_perception_msgs geometry_msgs npc_simulator rclcpp std_msgs unique_identifier_msgs)
+# ament_export_targets(export_scenario_api_simulator HAS_LIBRARY_TARGET)
+# ament_export_dependencies(autoware_perception_msgs geometry_msgs npc_simulator rclcpp std_msgs unique_identifier_msgs)
 
-install(TARGETS scenario_api_simulator
-  EXPORT export_scenario_api_simulator
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-)
+# install(TARGETS scenario_api_simulator
+#   EXPORT export_scenario_api_simulator
+#   ARCHIVE DESTINATION lib
+#   LIBRARY DESTINATION lib
+#   RUNTIME DESTINATION bin
+#   INCLUDES DESTINATION include
+# )
 
-install(DIRECTORY include/
-  DESTINATION include
-)
+# install(DIRECTORY include/
+#   DESTINATION include
+# )
 
 ament_package()
+
+message("${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}")
+set(PROJECT_TO_INSPECT npc_simulator)
+message("${PROJECT_TO_INSPECT} variables")
+# message("${${PROJECT_TO_INSPECT}_DEFINITIONS}")
+message("${${PROJECT_TO_INSPECT}_INCLUDE_DIRS}")
+# message("${${PROJECT_TO_INSPECT}_LIBRARIES}")
+# message("${${PROJECT_TO_INSPECT}_LINK_FLAGS}")
+# message("${${PROJECT_TO_INSPECT}_RECURSIVE_DEPENDENCIES}")
+message("targets: ${${PROJECT_TO_INSPECT}_TARGETS}")
+
+get_target_property(_include_dirs ${PROJECT_NAME} INTERFACE_INCLUDE_DIRECTORIES)
+message("${_include_dirs}")

--- a/api/scenario_api_simulator/include/scenario_api_simulator/npc_route_manager.h
+++ b/api/scenario_api_simulator/include/scenario_api_simulator/npc_route_manager.h
@@ -45,13 +45,13 @@ namespace lanelet
   }
 }  // namespace lanelet
 
-class NPCRouteManager: public rclcpp::Node
+class NPCRouteManager
 {
 public:
   /**
    * @brief constructor
    */
-  NPCRouteManager();
+  NPCRouteManager(rclcpp::Node::SharedPtr node);
 
   /**
    * @brief destructor
@@ -99,6 +99,8 @@ public:
   bool getNPCGoal(const std::string & name, geometry_msgs::msg::Pose * pose);
 
 private:
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
   rclcpp::Subscription < autoware_lanelet2_msgs::msg::MapBin > ::SharedPtr sub_map_;  //!< @brief topic subscriber for map
 
   // lanelet

--- a/api/scenario_api_simulator/include/scenario_api_simulator/npc_route_manager.h
+++ b/api/scenario_api_simulator/include/scenario_api_simulator/npc_route_manager.h
@@ -51,7 +51,7 @@ public:
   /**
    * @brief constructor
    */
-  NPCRouteManager(rclcpp::Node::SharedPtr node);
+  NPCRouteManager(rclcpp::Node& node);
 
   /**
    * @brief destructor

--- a/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
+++ b/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
@@ -17,26 +17,22 @@
 #ifndef SCENARIO_API_SCENARIO_API_SIMULATOR_H_INCLUDED
 #define SCENARIO_API_SCENARIO_API_SIMULATOR_H_INCLUDED
 
-#include <dummy_perception_publisher/InitialState.h>
-#include <npc_simulator/GetObject.h>
-#include <npc_simulator/Object.h>
-#include <ros/ros.h>
-#include <std_msgs/Bool.h>
-#include <tf2/convert.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <unique_id/unique_id.h>
-#include <unistd.h>
-#include <uuid/uuid.h>
+#include <geometry_msgs/msg/pose.hpp>
+#include <npc_simulator/srv/get_object.hpp>
+#include <npc_simulator/msg/object.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
 
-#include <iostream>
+#include <unistd.h>
+
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include <scenario_api_simulator/npc_route_manager.h>
-#include <scenario_api_utils/scenario_api_utils.h>
 
-class ScenarioAPISimulator
+class ScenarioAPISimulator: public rclcpp::Node
 {
 public:
   /**
@@ -54,29 +50,29 @@ public:
   bool updateState();  // update state //TODO
 
   // start API
-  bool spawnStartPoint(const geometry_msgs::Pose pose);  // spawn vehicle at start point
+  bool spawnStartPoint(const geometry_msgs::msg::Pose pose);  // spawn vehicle at start point
   bool sendEngage(const bool engage);                    //engage simulator and npc
   bool sendSimulatorEngage(const bool engage);           //engage simulator
   bool sendNPCEngage(const bool engage);                 //engage npc
 
   // NPC API
-  bool getNPC(const std::string & name, npc_simulator::Object & obj);
+  bool getNPC(const std::string & name, npc_simulator::msg::Object & obj);
   bool getNPC(
-    const std::string & name, geometry_msgs::Pose & object_pose,
-    geometry_msgs::Twist & object_twist, geometry_msgs::Vector3 & object_size,
+    const std::string & name, geometry_msgs::msg::Pose & object_pose,
+    geometry_msgs::msg::Twist & object_twist, geometry_msgs::msg::Vector3 & object_size,
     std::string & object_name);
-  bool getNPCPosition(const std::string & name, geometry_msgs::Pose * pose);
+  bool getNPCPosition(const std::string & name, geometry_msgs::msg::Pose * pose);
   bool getNPCVelocity(const std::string & name, double * velocity);
   bool getNPCAccel(const std::string & name, double * accel);
-  bool getNPCGoal(const std::string & name, geometry_msgs::Pose * pose);
+  bool getNPCGoal(const std::string & name, geometry_msgs::msg::Pose * pose);
   bool addNPC(
-    const std::string & npc_type, const std::string & name, geometry_msgs::Pose pose,
+    const std::string & npc_type, const std::string & name, geometry_msgs::msg::Pose pose,
     const double velocity, const bool stop_by_vehicle, const std::string & frame_type);
   bool sendNPCToCheckPoint(
-    const std::string & name, const geometry_msgs::Pose checkpoint_pose, const bool wait_ready,
+    const std::string & name, const geometry_msgs::msg::Pose checkpoint_pose, const bool wait_ready,
     const std::string frame_type);
   bool sendNPCToGoalPoint(
-    const std::string & name, const geometry_msgs::Pose pose, const bool wait_ready,
+    const std::string & name, const geometry_msgs::msg::Pose pose, const bool wait_ready,
     const std::string frame_type);
   bool changeNPCVelocity(const std::string & name, const double velocity);
   bool changeNPCVelocityWithoutAccel(const std::string & name, const double velocity);
@@ -96,43 +92,41 @@ public:
   bool checkNPCFinishLaneChange(const std::string & name, bool & lane_change);
   bool checkNPCFinishVelocityChange(const std::string & name, bool & velocity_change);
   bool deleteNPC(const std::string & name);
-  std::vector<std::string> getNpcList();
+  std::vector < std::string > getNpcList();
 
   //NPC API (tools)
   bool shiftNPCPose(
-    const geometry_msgs::Pose & pose, const std::string frame_type,
-    const npc_simulator::Object & obj, geometry_msgs::Pose * shift_pose);
+    const geometry_msgs::msg::Pose & pose, const std::string frame_type,
+    const npc_simulator::msg::Object & obj, geometry_msgs::msg::Pose * shift_pose);
 
   // traffic light API
   bool setTrafficLight(int traffic_id, std::string traffic_color);  // future work //TODO
 
 private:
-  ros::NodeHandle nh_;                   //!< @brief ros node handle
-  ros::NodeHandle pnh_;                  //!< @brief private ros node handle
-  ros::ServiceClient client_;            //!< @brief private ros service client
-  ros::Publisher pub_object_info_;       //!< @brief topic pubscriber for npc
-  ros::Publisher pub_simulator_engage_;  //!< @brief topic pubscriber for vehicle engage
-  ros::Publisher pub_npc_engage_;        //!< @brief topic pubscriber for npc simulator engage
-  ros::Timer timer_control_;             //!< @brief timer for getting self-position
-  std::unordered_map<std::string, uuid_msgs::UniqueID> uuid_map_;
-  std::unordered_map<std::string, double> maxacc_map_;
-  std::unordered_map<std::string, double> minacc_map_;
-  std::shared_ptr<NPCRouteManager> npc_route_manager_;
+  rclcpp::Client < npc_simulator::srv::GetObject > ::SharedPtr client_;            //!< @brief private ros service client
+  rclcpp::Publisher < npc_simulator::msg::Object > ::SharedPtr pub_object_info_;       //!< @brief topic pubscriber for npc
+  rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_simulator_engage_;  //!< @brief topic pubscriber for vehicle engage
+  rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_npc_engage_;        //!< @brief topic pubscriber for npc simulator engage
+  rclcpp::TimerBase::SharedPtr timer_control_;             //!< @brief timer for getting self-position
+  std::unordered_map < std::string, unique_identifier_msgs::msg::UUID > uuid_map_;
+  std::unordered_map < std::string, double > maxacc_map_;
+  std::unordered_map < std::string, double > minacc_map_;
+  std::shared_ptr < NPCRouteManager > npc_route_manager_;
 
-  void timerCallback(const ros::TimerEvent & te);
+  void timerCallback();
   void updateNPC();
-  npc_simulator::Object getObjectMsg(
+  npc_simulator::msg::Object getObjectMsg(
     uint32_t semantic_type, double confidence, uint8_t shape_type, double size_x, double size_y,
     double size_z);
-  std::unordered_map<std::string, npc_simulator::Object> getNPCInfo();
-  npc_simulator::Object getObjectMsg(std::string npc_name, std::string frame_id = "map");
+  std::unordered_map < std::string, npc_simulator::msg::Object > getNPCInfo();
+  npc_simulator::msg::Object getObjectMsg(std::string npc_name, std::string frame_id = "map");
   bool checkValidNPC(const std::string & name);
-  bool changeNPCRoute(const std::string & name, const std::vector<int> route);
+  bool changeNPCRoute(const std::string & name, const std::vector < int > route);
   bool targetLaneChangeNPC(const std::string & name, const int target_lane_id);
   bool laneChangeNPC(const std::string & name, const uint8_t lane_change_dir);
   bool changeNPCBehavior(const std::string & name, const uint8_t behavior_mode);
-  bool inputNPCLaneFollowState(std::unordered_map<std::string, uint8_t> states);
-  bool inputNPCStopState(std::unordered_map<std::string, bool> states);
+  bool inputNPCLaneFollowState(std::unordered_map < std::string, uint8_t > states);
+  bool inputNPCStopState(std::unordered_map < std::string, bool > states);
 
   //parameter
   const double npc_stop_accel_ = 3.0;

--- a/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
+++ b/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
@@ -106,7 +106,7 @@ public:
 private:
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
-  std::shared_ptr < NPCSimulatorNode > npc_simulator_;
+  std::shared_ptr < NPCSimulator > npc_simulator_;
   rclcpp::Publisher < npc_simulator::msg::Object > ::SharedPtr pub_object_info_;       //!< @brief topic pubscriber for npc
   rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_simulator_engage_;  //!< @brief topic pubscriber for vehicle engage
   rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_npc_engage_;        //!< @brief topic pubscriber for npc simulator engage

--- a/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
+++ b/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
@@ -23,6 +23,7 @@
 #include <unique_identifier_msgs/msg/uuid.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
+#include <npc_simulator/node.h>
 
 #include <unistd.h>
 
@@ -105,7 +106,7 @@ public:
 private:
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
-  rclcpp::Client < npc_simulator::srv::GetObject > ::SharedPtr client_;            //!< @brief private ros service client
+  std::shared_ptr < NPCSimulatorNode > npc_simulator_;
   rclcpp::Publisher < npc_simulator::msg::Object > ::SharedPtr pub_object_info_;       //!< @brief topic pubscriber for npc
   rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_simulator_engage_;  //!< @brief topic pubscriber for vehicle engage
   rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_npc_engage_;        //!< @brief topic pubscriber for npc simulator engage

--- a/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
+++ b/api/scenario_api_simulator/include/scenario_api_simulator/scenario_api_simulator.h
@@ -32,13 +32,13 @@
 
 #include <scenario_api_simulator/npc_route_manager.h>
 
-class ScenarioAPISimulator: public rclcpp::Node
+class ScenarioAPISimulator
 {
 public:
   /**
    * @brief constructor
    */
-  ScenarioAPISimulator();
+  ScenarioAPISimulator(rclcpp::Node::SharedPtr node);
 
   /**
    * @brief destructor
@@ -103,6 +103,8 @@ public:
   bool setTrafficLight(int traffic_id, std::string traffic_color);  // future work //TODO
 
 private:
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
   rclcpp::Client < npc_simulator::srv::GetObject > ::SharedPtr client_;            //!< @brief private ros service client
   rclcpp::Publisher < npc_simulator::msg::Object > ::SharedPtr pub_object_info_;       //!< @brief topic pubscriber for npc
   rclcpp::Publisher < std_msgs::msg::Bool > ::SharedPtr pub_simulator_engage_;  //!< @brief topic pubscriber for vehicle engage

--- a/api/scenario_api_simulator/package.xml
+++ b/api/scenario_api_simulator/package.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" ?>
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>scenario_api_simulator</name>
   <version>0.0.0</version>
   <description>The scenario_api_simulator package</description>
@@ -7,22 +8,22 @@
   <author email="tomoya.kimura@tier4.jp">Tomoya Kimura</author>
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>sensor_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
-  <depend>autoware_system_msgs</depend>
+  <build_depend>dummy_perception_publisher</build_depend>
+  <build_depend>lanelet2_extension</build_depend>
+  <build_depend>scenario_api_utils</build_depend>
+  <build_depend>tf2</build_depend>
+  <depend>autoware_lanelet2_msgs</depend>
   <depend>autoware_perception_msgs</depend>
-  <depend>autoware_vehicle_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>npc_simulator</depend>
-  <depend>roscpp</depend>
-  <depend>tf2</depend>
-  <depend>tf2_ros</depend>
-  <depend>pcl_ros</depend>
-  <depend>pcl_conversions</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>lanelet2_extension</depend>
-  <depend>scenario_api_utils</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/api/scenario_api_simulator/package.xml
+++ b/api/scenario_api_simulator/package.xml
@@ -22,6 +22,8 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>
+  <!-- TODO: This is not a dependency, only a workaround for build problems -->
+  <depend>vehicle_info_util</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/api/scenario_api_simulator/package.xml
+++ b/api/scenario_api_simulator/package.xml
@@ -22,8 +22,6 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>
-  <!-- TODO: This is not a dependency, only a workaround for build problems -->
-  <depend>vehicle_info_util</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/api/scenario_api_simulator/package.xml
+++ b/api/scenario_api_simulator/package.xml
@@ -10,17 +10,17 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>dummy_perception_publisher</build_depend>
-  <build_depend>lanelet2_extension</build_depend>
-  <build_depend>scenario_api_utils</build_depend>
-  <build_depend>tf2</build_depend>
   <depend>autoware_lanelet2_msgs</depend>
   <depend>autoware_perception_msgs</depend>
+  <build_depend>dummy_perception_publisher</build_depend>
   <depend>geometry_msgs</depend>
+  <build_depend>lanelet2_extension</build_depend>
   <depend>npc_simulator</depend>
   <depend>rclcpp</depend>
+  <build_depend>scenario_api_utils</build_depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <build_depend>tf2</build_depend>
   <depend>unique_identifier_msgs</depend>
 
   <export>

--- a/api/scenario_api_simulator/src/npc_route_manager.cpp
+++ b/api/scenario_api_simulator/src/npc_route_manager.cpp
@@ -22,11 +22,11 @@
 
 #include <functional>
 
-NPCRouteManager::NPCRouteManager(rclcpp::Node::SharedPtr node)
-: logger_(node->get_logger().get_child("npcl_route_manager")),
-  clock_(node->get_clock())
+NPCRouteManager::NPCRouteManager(rclcpp::Node& node)
+: logger_(node.get_logger().get_child("npcl_route_manager")),
+  clock_(node.get_clock())
 {
-  sub_map_ = node->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
+  sub_map_ = node.create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
     "input/vectormap", 1, std::bind(
       &NPCRouteManager::callbackMap, this,
       std::placeholders::_1));

--- a/api/scenario_api_simulator/src/scenario_api_simulator.cpp
+++ b/api/scenario_api_simulator/src/scenario_api_simulator.cpp
@@ -16,28 +16,50 @@
 
 #include <scenario_api_simulator/scenario_api_simulator.h>
 
-ScenarioAPISimulator::ScenarioAPISimulator() : nh_(""), pnh_("~")
+#include <autoware_perception_msgs/msg/semantic.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <dummy_perception_publisher/msg/initial_state.hpp>
+#include <scenario_api_utils/scenario_api_utils.h>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <functional>
+#include <random>
+
+ScenarioAPISimulator::ScenarioAPISimulator()
+: rclcpp::Node("scenario_api_simulator")
 {
   /* initializer*/
   npc_route_manager_ = std::make_shared<NPCRouteManager>();
 
   /* register service client*/
-  client_ = nh_.serviceClient<npc_simulator::GetObject>(
-    "/simulation/npc_simulator/"
-    "get_object");
+  client_ = this->create_client<npc_simulator::srv::GetObject>(
+    "/simulation/npc_simulator/srv/get_object");
 
   /* register publisher */
-  pub_object_info_ = pnh_.advertise<npc_simulator::Object>("output/object_info", 1, true);
-  pub_simulator_engage_ = pnh_.advertise<std_msgs::Bool>("output/simulator_engage", 1, true);
-  pub_npc_engage_ = pnh_.advertise<std_msgs::Bool>("output/npc_simulator_engage", 1, true);
+  rclcpp::QoS durable_qos{1};
+  durable_qos.transient_local();
+  pub_object_info_ = this->create_publisher<npc_simulator::msg::Object>(
+    "output/object_info",
+    durable_qos);
+  pub_simulator_engage_ = this->create_publisher<std_msgs::msg::Bool>(
+    "output/simulator_engage",
+    durable_qos);
+  pub_npc_engage_ = this->create_publisher<std_msgs::msg::Bool>(
+    "output/npc_simulator_engage",
+    durable_qos);
 
-  timer_control_ =
-    pnh_.createTimer(ros::Duration(0.02), &ScenarioAPISimulator::timerCallback, this);
+  auto timer_callback = std::bind(&ScenarioAPISimulator::timerCallback, this);
+  auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::duration<double>(0.02));
+  timer_control_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
+    this->get_clock(), period, std::move(timer_callback),
+    this->get_node_base_interface()->get_context());
+  this->get_node_timers_interface()->add_timer(timer_control_, nullptr);
 }
 
 ScenarioAPISimulator::~ScenarioAPISimulator() {}
 
-void ScenarioAPISimulator::timerCallback(const ros::TimerEvent & te) { updateState(); }
+void ScenarioAPISimulator::timerCallback() {updateState();}
 
 // basic API
 
@@ -51,13 +73,12 @@ bool ScenarioAPISimulator::isAPIReady()
 
 bool ScenarioAPISimulator::updateState()
 {
-  ros::spinOnce();
   updateNPC();
   return true;
 }
 
 // start API
-bool ScenarioAPISimulator::spawnStartPoint(const geometry_msgs::Pose pose)
+bool ScenarioAPISimulator::spawnStartPoint(const geometry_msgs::msg::Pose pose)
 {
   // spawn vehicle (planning simulator needs nothing)
   return true;
@@ -70,89 +91,88 @@ bool ScenarioAPISimulator::sendEngage(const bool engage)
 
 bool ScenarioAPISimulator::sendSimulatorEngage(const bool engage)
 {
-  std_msgs::Bool boolmsg;
+  std_msgs::msg::Bool boolmsg;
   boolmsg.data = engage;
-  pub_simulator_engage_.publish(boolmsg);
+  pub_simulator_engage_->publish(boolmsg);
   return true;  // TODO check success
 }
 
 bool ScenarioAPISimulator::sendNPCEngage(const bool engage)
 {
-  std_msgs::Bool boolmsg;
+  std_msgs::msg::Bool boolmsg;
   boolmsg.data = engage;
-  pub_npc_engage_.publish(boolmsg);
+  pub_npc_engage_->publish(boolmsg);
   return true;  // TODO check success
 }
 
 // NPC API
 bool ScenarioAPISimulator::addNPC(
-  const std::string & npc_type, const std::string & name, geometry_msgs::Pose pose,
+  const std::string & npc_type, const std::string & name, geometry_msgs::msg::Pose pose,
   const double velocity, const bool stop_by_vehicle, const std::string & frame_type)
 {
   // uuid map check
   if (uuid_map_.find(name) != uuid_map_.end()) {
-    ROS_WARN_STREAM("NPC name :" << name << " already exsists");
+    RCLCPP_WARN_STREAM(get_logger(), "NPC name :" << name << " already exsists");
     return true;
-  }
-  else {
-    // generate uuid_map
-    uuid_map_[name] = unique_id::toMsg(boost::uuids::random_generator()());
+  } else {
+    // generate random UUID
+    unique_identifier_msgs::msg::UUID id;
+    std::mt19937 gen(std::random_device{} ());
+    std::independent_bits_engine<std::mt19937, 8, uint8_t> bit_eng(gen);
+    std::generate(id.uuid.begin(), id.uuid.end(), bit_eng);
+    uuid_map_[name] = id;
   }
 
-  static const std::unordered_map<std::string, npc_simulator::Object> objects
+  static const std::unordered_map<std::string, npc_simulator::msg::Object> objects
   {
     #define MAKE_OBJECT(TYPE, ...) \
-      getObjectMsg( \
-        autoware_perception_msgs::Semantic::TYPE, 1.0, \
-        autoware_perception_msgs::Shape::BOUNDING_BOX, __VA_ARGS__)
+  getObjectMsg( \
+    autoware_perception_msgs::msg::Semantic::TYPE, 1.0, \
+    autoware_perception_msgs::msg::Shape::BOUNDING_BOX, __VA_ARGS__)
 
-    { "car",        MAKE_OBJECT(CAR,        4.0, 1.8, 2.5) },
-    { "pedestrian", MAKE_OBJECT(PEDESTRIAN, 0.8, 0.8, 2.0) },
-    { "bicycle",    MAKE_OBJECT(BICYCLE,    2.0, 0.8, 2.5) },
-    { "motorbike",  MAKE_OBJECT(MOTORBIKE,  2.5, 1.5, 2.5) },
-    { "bus",        MAKE_OBJECT(BUS,       10.0, 2.5, 3.5) },
-    { "truck",      MAKE_OBJECT(TRUCK,      7.5, 2.5, 3.0) },
-    { "unknown",    MAKE_OBJECT(UNKNOWN,    1.0, 1.0, 1.0) }
+    {"car", MAKE_OBJECT(CAR, 4.0, 1.8, 2.5)},
+    {"pedestrian", MAKE_OBJECT(PEDESTRIAN, 0.8, 0.8, 2.0)},
+    {"bicycle", MAKE_OBJECT(BICYCLE, 2.0, 0.8, 2.5)},
+    {"motorbike", MAKE_OBJECT(MOTORBIKE, 2.5, 1.5, 2.5)},
+    {"bus", MAKE_OBJECT(BUS, 10.0, 2.5, 3.5)},
+    {"truck", MAKE_OBJECT(TRUCK, 7.5, 2.5, 3.0)},
+    {"unknown", MAKE_OBJECT(UNKNOWN, 1.0, 1.0, 1.0)}
 
     #undef MAKE_OBJECT
   };
 
-  npc_simulator::Object object;
+  npc_simulator::msg::Object object;
 
-  try
-  {
+  try {
     object = objects.at(npc_type);
     object.offset_rate_from_center = (npc_type == "bicycle" ? 0.95 : 0); // Bicycle runs on left edge of lane
-  }
-  catch (std::out_of_range&)
-  {
-    ROS_WARN("NPC type is invalid. Publish NPC object as unknown type");
+  } catch (std::out_of_range &) {
+    RCLCPP_WARN(get_logger(), "NPC type is invalid. Publish NPC object as unknown type");
     object = objects.at("unknown");
   }
 
   //get pose with frame_type
-  geometry_msgs::Pose original_pose;
+  geometry_msgs::msg::Pose original_pose;
   original_pose.position = pose.position;
   original_pose.orientation = quatFromYaw(yawFromQuat(pose.orientation)); // ignore roll/pitch information
 
-  dummy_perception_publisher::InitialState init_state;
+  dummy_perception_publisher::msg::InitialState init_state;
   if (!shiftNPCPose(original_pose, frame_type, object, &init_state.pose_covariance.pose)) {
     return false;
   }
 
-  object.header.stamp = ros::Time::now();
+  object.header.stamp = this->now();
   object.header.frame_id = "map";
   object.initial_state = init_state;
   object.initial_state.twist_covariance.twist.linear.x = velocity;
   object.target_vel = velocity;
   object.accel = npc_default_accel_;
   object.id = uuid_map_[name];
-  object.action = npc_simulator::Object::ADD;
+  object.action = npc_simulator::msg::Object::ADD;
   object.stop_by_vehicle = stop_by_vehicle;
 
-  for (npc_simulator::Object result {}; not getNPC(name, result); sleep(0.1))
-  {
-    pub_object_info_.publish(object);
+  for (npc_simulator::msg::Object result {}; not getNPC(name, result); sleep(0.1)) {
+    pub_object_info_->publish(object);
   }
 
   return true;  // TODO check successs
@@ -161,7 +181,7 @@ bool ScenarioAPISimulator::addNPC(
 bool ScenarioAPISimulator::checkValidNPC(const std::string & name)
 {
   if (uuid_map_.find(name) == uuid_map_.end()) {
-    ROS_WARN_STREAM("NPC name :" << name << " does not exist");
+    RCLCPP_WARN_STREAM(get_logger(), "NPC name :" << name << " does not exist");
     return false;
   } else {
     return true;
@@ -169,10 +189,10 @@ bool ScenarioAPISimulator::checkValidNPC(const std::string & name)
 }
 
 bool ScenarioAPISimulator::sendNPCToCheckPoint(
-  const std::string & name, const geometry_msgs::Pose checkpoint_pose, const bool wait_ready,
+  const std::string & name, const geometry_msgs::msg::Pose checkpoint_pose, const bool wait_ready,
   const std::string frame_type)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
@@ -181,10 +201,10 @@ bool ScenarioAPISimulator::sendNPCToCheckPoint(
     //if obj has minus velocity, do nothing
     return true;
   }
-  geometry_msgs::Pose initial_pose = obj.initial_state.pose_covariance.pose;
+  geometry_msgs::msg::Pose initial_pose = obj.initial_state.pose_covariance.pose;
 
   //get pose with frame_type
-  geometry_msgs::Pose shift_checkpoint_pose;
+  geometry_msgs::msg::Pose shift_checkpoint_pose;
   if (!shiftNPCPose(checkpoint_pose, frame_type, obj, &shift_checkpoint_pose)) {
     return false;
   }
@@ -192,7 +212,7 @@ bool ScenarioAPISimulator::sendNPCToCheckPoint(
   npc_route_manager_->setCheckPoint(name, shift_checkpoint_pose);
 
   //if goal pose is already given, replan route.
-  geometry_msgs::Pose goal_pose;
+  geometry_msgs::msg::Pose goal_pose;
   if (getNPCGoal(name, &goal_pose)) {
     std::vector<int> route;
     if (!npc_route_manager_->planRoute(name, initial_pose, goal_pose, &route)) {
@@ -204,10 +224,10 @@ bool ScenarioAPISimulator::sendNPCToCheckPoint(
 }
 
 bool ScenarioAPISimulator::sendNPCToGoalPoint(
-  const std::string & name, const geometry_msgs::Pose goal_pose, const bool wait_ready,
+  const std::string & name, const geometry_msgs::msg::Pose goal_pose, const bool wait_ready,
   const std::string frame_type)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
@@ -216,13 +236,13 @@ bool ScenarioAPISimulator::sendNPCToGoalPoint(
     //if obj has minus velocity, do nothing
     return true;
   }
-  geometry_msgs::Pose initial_pose = obj.initial_state.pose_covariance.pose;
+  geometry_msgs::msg::Pose initial_pose = obj.initial_state.pose_covariance.pose;
   if (!getNPCPosition(name, &initial_pose)) {
     return false;
   }
 
   //get pose with frame_type
-  geometry_msgs::Pose shift_goal_pose;
+  geometry_msgs::msg::Pose shift_goal_pose;
   if (!shiftNPCPose(goal_pose, frame_type, obj, &shift_goal_pose)) {
     return false;
   }
@@ -242,7 +262,7 @@ bool ScenarioAPISimulator::sendNPCToGoalPoint(
 bool ScenarioAPISimulator::changeNPCVelocity(const std::string & name, const double velocity)
 {
   //get object current velocity
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     //case: cannot get object info
     //sudden velocity change
@@ -276,11 +296,11 @@ bool ScenarioAPISimulator::changeNPCVelocityWithoutAccel(
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYTWIST;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYTWIST;
   object.initial_state.twist_covariance.twist.linear.x = velocity;
   object.target_vel = velocity;
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
   return true;
 }
@@ -305,11 +325,11 @@ bool ScenarioAPISimulator::changeNPCVelocityWithAccel(
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYACCEL;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYACCEL;
   object.target_vel = velocity;
   object.accel = accel;
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
 
   return true;
@@ -323,10 +343,10 @@ bool ScenarioAPISimulator::changeNPCConsiderVehicle(
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYCONSIDERVEHICLE;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYCONSIDERVEHICLE;
   object.stop_by_vehicle = consider_ego_vehicle;
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
 
   return true;
@@ -339,16 +359,17 @@ bool ScenarioAPISimulator::changeNPCRoute(const std::string & name, const std::v
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYROUTE;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYROUTE;
   object.target_route.data.clear();
   for (auto lane : route) {
     //input lane id list
     object.target_route.data.push_back(lane);
   }
 
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
+  return true;
 }
 
 bool ScenarioAPISimulator::targetLaneChangeNPC(const std::string & name, const int target_lane_id)
@@ -358,10 +379,10 @@ bool ScenarioAPISimulator::targetLaneChangeNPC(const std::string & name, const i
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYTARGETLANE;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYTARGETLANE;
   object.lane_change_id = target_lane_id;
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
 
   return true;
@@ -374,10 +395,10 @@ bool ScenarioAPISimulator::laneChangeNPC(const std::string & name, const uint8_t
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYLANECHANGE;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYLANECHANGE;
   object.lane_change_dir.dir = lane_change_dir;
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
 
   return true;
@@ -385,12 +406,12 @@ bool ScenarioAPISimulator::laneChangeNPC(const std::string & name, const uint8_t
 
 bool ScenarioAPISimulator::changeNPCLaneChangeLeft(const std::string & name)
 {
-  return laneChangeNPC(name, npc_simulator::LaneChangeDir::LEFT_LANE_CHANGE);
+  return laneChangeNPC(name, npc_simulator::msg::LaneChangeDir::LEFT_LANE_CHANGE);
 }
 
 bool ScenarioAPISimulator::changeNPCLaneChangeRight(const std::string & name)
 {
-  return laneChangeNPC(name, npc_simulator::LaneChangeDir::RIGHT_LANE_CHANGE);
+  return laneChangeNPC(name, npc_simulator::msg::LaneChangeDir::RIGHT_LANE_CHANGE);
 }
 
 bool ScenarioAPISimulator::changeNPCLaneChange(const std::string & name, const int target_lane_id)
@@ -400,7 +421,7 @@ bool ScenarioAPISimulator::changeNPCLaneChange(const std::string & name, const i
 
 bool ScenarioAPISimulator::changeNPCUturn(const std::string & name)
 {
-  return laneChangeNPC(name, npc_simulator::LaneChangeDir::LANE_CHANGE_UTURN);
+  return laneChangeNPC(name, npc_simulator::msg::LaneChangeDir::LANE_CHANGE_UTURN);
 }
 
 bool ScenarioAPISimulator::changeNPCBehavior(const std::string & name, const uint8_t behavior_mode)
@@ -410,10 +431,10 @@ bool ScenarioAPISimulator::changeNPCBehavior(const std::string & name, const uin
   }
 
   // generate object info
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::MODIFYTURNDIRECTION;
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::MODIFYTURNDIRECTION;
   object.lane_follow_mode.mode = behavior_mode;
-  pub_object_info_.publish(object);
+  pub_object_info_->publish(object);
   sleep(0.01);  // TODO remove this(sleep for avoiding message loss)
 
   return true;
@@ -421,33 +442,33 @@ bool ScenarioAPISimulator::changeNPCBehavior(const std::string & name, const uin
 
 bool ScenarioAPISimulator::changeNPCTurnLeft(const std::string & name)
 {
-  return changeNPCBehavior(name, npc_simulator::LaneFollowMode::MOVE_LANE_FOLLOW_LEFT);
+  return changeNPCBehavior(name, npc_simulator::msg::LaneFollowMode::MOVE_LANE_FOLLOW_LEFT);
 }
 
 bool ScenarioAPISimulator::changeNPCTurnRight(const std::string & name)
 {
-  return changeNPCBehavior(name, npc_simulator::LaneFollowMode::MOVE_LANE_FOLLOW_RIGHT);
+  return changeNPCBehavior(name, npc_simulator::msg::LaneFollowMode::MOVE_LANE_FOLLOW_RIGHT);
 }
 
 bool ScenarioAPISimulator::changeNPCNoTurn(const std::string & name)
 {
-  return changeNPCBehavior(name, npc_simulator::LaneFollowMode::MOVE_LANE_FOLLOW_STRAIGHT);
+  return changeNPCBehavior(name, npc_simulator::msg::LaneFollowMode::MOVE_LANE_FOLLOW_STRAIGHT);
 }
 
 bool ScenarioAPISimulator::changeNPCIgnoreLane(const std::string & name)
 {
-  return changeNPCBehavior(name, npc_simulator::LaneFollowMode::MOVE_STRAIGHT);
+  return changeNPCBehavior(name, npc_simulator::msg::LaneFollowMode::MOVE_STRAIGHT);
 }
 
 bool ScenarioAPISimulator::checkNPCFinishLaneChange(
   const std::string & name, bool & end_lane_change)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
 
-  if (obj.lane_change_dir.dir == npc_simulator::LaneChangeDir::NO_LANE_CHANGE) {
+  if (obj.lane_change_dir.dir == npc_simulator::msg::LaneChangeDir::NO_LANE_CHANGE) {
     end_lane_change = true;
   } else {
     end_lane_change = false;
@@ -459,7 +480,7 @@ bool ScenarioAPISimulator::checkNPCFinishLaneChange(
 bool ScenarioAPISimulator::checkNPCFinishVelocityChange(
   const std::string & name, bool & end_velocity_change)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
@@ -487,9 +508,9 @@ bool ScenarioAPISimulator::deleteNPC(const std::string & name)
     return false;
   }
 
-  npc_simulator::Object object = getObjectMsg(name);
-  object.action = npc_simulator::Object::DELETE;
-  pub_object_info_.publish(object);
+  npc_simulator::msg::Object object = getObjectMsg(name);
+  object.action = npc_simulator::msg::Object::DELETE;
+  pub_object_info_->publish(object);
 
   // delete uuid map
   uuid_map_.erase(name);
@@ -509,7 +530,7 @@ std::vector<std::string> ScenarioAPISimulator::getNpcList()
 
 void ScenarioAPISimulator::updateNPC()
 {
-  std::unordered_map<std::string, npc_simulator::Object> npc_infos = getNPCInfo();
+  std::unordered_map<std::string, npc_simulator::msg::Object> npc_infos = getNPCInfo();
   std::unordered_map<std::string, uint8_t> npc_follow_states =
     npc_route_manager_->updateNPCLaneFollowState(npc_infos);
   inputNPCLaneFollowState(npc_follow_states);
@@ -518,56 +539,49 @@ void ScenarioAPISimulator::updateNPC()
   inputNPCStopState(npc_stop_states);
 }
 
-bool ScenarioAPISimulator::getNPC(const std::string & name, npc_simulator::Object & obj)
+bool ScenarioAPISimulator::getNPC(const std::string & name, npc_simulator::msg::Object & obj)
 {
-  if (!checkValidNPC(name))
-  {
-    ROS_WARN_STREAM("Invalid NPC name '" << name << "' requested.");
+  if (!checkValidNPC(name)) {
+    RCLCPP_WARN_STREAM(get_logger(), "Invalid NPC name '" << name << "' requested.");
     return false;
-  }
-  else
-  {
-    npc_simulator::GetObject srv;
+  } else {
+    auto req = std::make_shared<npc_simulator::srv::GetObject::Request>();
+    req->object_id = uuid_map_.at(name);
 
-    srv.request.object_id = uuid_map_[name];
-
-    if (not client_.call(srv) or not srv.response.success)
-    {
-      ROS_WARN_STREAM("Failed to get NPC");
-      return false;
-    }
-    else
-    {
-      obj = srv.response.object;
+    auto res_future = client_->async_send_request(req);
+    auto status = res_future.wait_for(std::chrono::microseconds(1000));
+    if (status == std::future_status::ready) {
+      obj = res_future.get()->object;
       return true;
+    } else {
+      RCLCPP_WARN_STREAM(get_logger(), "Failed to get NPC");
+      return false;
     }
   }
 }
 
 bool ScenarioAPISimulator::getNPC(
-  const std::string & name, geometry_msgs::Pose & object_pose, geometry_msgs::Twist & object_twist,
-  geometry_msgs::Vector3 & object_size, std::string & object_name)
+  const std::string & name, geometry_msgs::msg::Pose & object_pose,
+  geometry_msgs::msg::Twist & object_twist,
+  geometry_msgs::msg::Vector3 & object_size, std::string & object_name)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
 
-  if (!getNPC(name, obj))
-  {
+  if (!getNPC(name, obj)) {
     return false;
-  }
-  else
-  {
-    object_pose  = obj.initial_state.pose_covariance.pose;
+  } else {
+    object_pose = obj.initial_state.pose_covariance.pose;
     object_twist = obj.initial_state.twist_covariance.twist;
-    object_size  = obj.shape.dimensions;
+    object_size = obj.shape.dimensions;
 
     switch (obj.semantic.type) {
-      case autoware_perception_msgs::Semantic::BICYCLE:    { object_name = "bicycle";    break; }
-      case autoware_perception_msgs::Semantic::BUS:        { object_name = "bus";        break; }
-      case autoware_perception_msgs::Semantic::CAR:        { object_name = "car";        break; }
-      case autoware_perception_msgs::Semantic::MOTORBIKE:  { object_name = "motorbike";  break; }
-      case autoware_perception_msgs::Semantic::PEDESTRIAN: { object_name = "pedestrian"; break; }
-      case autoware_perception_msgs::Semantic::TRUCK:      { object_name = "truck";      break; }
-      case autoware_perception_msgs::Semantic::UNKNOWN:    { object_name = "unknown";    break; }
+      case autoware_perception_msgs::msg::Semantic::BICYCLE:    {object_name = "bicycle";    break;}
+      case autoware_perception_msgs::msg::Semantic::BUS:        {object_name = "bus";        break;}
+      case autoware_perception_msgs::msg::Semantic::CAR:        {object_name = "car";        break;}
+      case autoware_perception_msgs::msg::Semantic::MOTORBIKE:  {object_name = "motorbike";  break;}
+      case autoware_perception_msgs::msg::Semantic::PEDESTRIAN: {object_name = "pedestrian"; break;}
+      case autoware_perception_msgs::msg::Semantic::TRUCK:      {object_name = "truck";      break;}
+      case autoware_perception_msgs::msg::Semantic::UNKNOWN:    {object_name = "unknown";    break;}
 
       default:
         object_name = "else";
@@ -577,9 +591,9 @@ bool ScenarioAPISimulator::getNPC(
   }
 }
 
-bool ScenarioAPISimulator::getNPCPosition(const std::string & name, geometry_msgs::Pose * pose)
+bool ScenarioAPISimulator::getNPCPosition(const std::string & name, geometry_msgs::msg::Pose * pose)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
@@ -590,7 +604,7 @@ bool ScenarioAPISimulator::getNPCPosition(const std::string & name, geometry_msg
 
 bool ScenarioAPISimulator::getNPCVelocity(const std::string & name, double * velocity)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
@@ -601,7 +615,7 @@ bool ScenarioAPISimulator::getNPCVelocity(const std::string & name, double * vel
 
 bool ScenarioAPISimulator::getNPCAccel(const std::string & name, double * accel)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   if (!getNPC(name, obj)) {
     return false;
   }
@@ -610,17 +624,17 @@ bool ScenarioAPISimulator::getNPCAccel(const std::string & name, double * accel)
   return true;
 }
 
-bool ScenarioAPISimulator::getNPCGoal(const std::string & name, geometry_msgs::Pose * pose)
+bool ScenarioAPISimulator::getNPCGoal(const std::string & name, geometry_msgs::msg::Pose * pose)
 {
   return npc_route_manager_->getNPCGoal(name, pose);
 }
 
-std::unordered_map<std::string, npc_simulator::Object> ScenarioAPISimulator::getNPCInfo()
+std::unordered_map<std::string, npc_simulator::msg::Object> ScenarioAPISimulator::getNPCInfo()
 {
-  std::unordered_map<std::string, npc_simulator::Object> npc_infos;
+  std::unordered_map<std::string, npc_simulator::msg::Object> npc_infos;
   for (auto npc : uuid_map_) {
     std::string name = npc.first;
-    npc_simulator::Object obj;
+    npc_simulator::msg::Object obj;
     if (getNPC(name, obj)) {
       npc_infos[name] = obj;
     }
@@ -630,13 +644,14 @@ std::unordered_map<std::string, npc_simulator::Object> ScenarioAPISimulator::get
 }
 
 bool ScenarioAPISimulator::shiftNPCPose(
-  const geometry_msgs::Pose & pose, const std::string frame_type, const npc_simulator::Object & obj,
-  geometry_msgs::Pose * shift_pose)
+  const geometry_msgs::msg::Pose & pose, const std::string frame_type,
+  const npc_simulator::msg::Object & obj,
+  geometry_msgs::msg::Pose * shift_pose)
 {
   // shift pose from farame_type to "Center"
 
-  if (obj.shape.type == autoware_perception_msgs::Shape::POLYGON) {
-    ROS_ERROR_STREAM("Now, npc with polygon type is not supported");
+  if (obj.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    RCLCPP_ERROR_STREAM(get_logger(), "Now, npc with polygon type is not supported");
     return false;
   }
 
@@ -660,17 +675,18 @@ bool ScenarioAPISimulator::shiftNPCPose(
     return true;
   }
 
-  ROS_ERROR_STREAM(
-    "shiftEGoPose supports only Center, Front, and Rear as frame_type. "
-    << "Now, frame_type is " << frame_type << ".");
+  RCLCPP_ERROR_STREAM(
+    get_logger(),
+    "shiftEGoPose supports only Center, Front, and Rear as frame_type. " <<
+      "Now, frame_type is " << frame_type << ".");
   return false;
 }
 
-npc_simulator::Object ScenarioAPISimulator::getObjectMsg(
+npc_simulator::msg::Object ScenarioAPISimulator::getObjectMsg(
   uint32_t semantic_type, double confidence, uint8_t shape_type, double size_x, double size_y,
   double size_z)
 {
-  npc_simulator::Object obj;
+  npc_simulator::msg::Object obj;
   obj.semantic.type = semantic_type;
   obj.semantic.confidence = confidence;
   obj.shape.type = shape_type;
@@ -680,13 +696,15 @@ npc_simulator::Object ScenarioAPISimulator::getObjectMsg(
   return obj;
 }
 
-npc_simulator::Object ScenarioAPISimulator::getObjectMsg(std::string npc_name, std::string frame_id)
+npc_simulator::msg::Object ScenarioAPISimulator::getObjectMsg(
+  std::string npc_name,
+  std::string frame_id)
 {
-  std_msgs::Header header;
-  header.stamp = ros::Time::now();
+  std_msgs::msg::Header header;
+  header.stamp = this->now();
   header.frame_id = frame_id;
 
-  npc_simulator::Object object;
+  npc_simulator::msg::Object object;
   object.header = header;
   object.id = uuid_map_[npc_name];
   return object;
@@ -719,7 +737,7 @@ bool ScenarioAPISimulator::inputNPCStopState(std::unordered_map<std::string, boo
 // traffic light API
 bool ScenarioAPISimulator::setTrafficLight(int traffic_id, std::string traffic_color)
 {
-  ROS_WARN("setTrafficLight is not implemented yet.");
+  RCLCPP_WARN(get_logger(), "setTrafficLight is not implemented yet.");
   // TODO
   return false;
 }

--- a/api/scenario_api_simulator/src/scenario_api_simulator.cpp
+++ b/api/scenario_api_simulator/src/scenario_api_simulator.cpp
@@ -30,7 +30,7 @@ ScenarioAPISimulator::ScenarioAPISimulator(rclcpp::Node::SharedPtr node)
   clock_(node->get_clock())
 {
   /* initializer*/
-  npc_route_manager_ = std::make_shared<NPCRouteManager>(node);
+  npc_route_manager_ = std::make_shared<NPCRouteManager>(*node);
   npc_simulator_ = std::make_shared<NPCSimulatorNode>(*node);
 
   /* register publisher */

--- a/api/scenario_api_simulator/src/scenario_api_simulator.cpp
+++ b/api/scenario_api_simulator/src/scenario_api_simulator.cpp
@@ -30,7 +30,7 @@ ScenarioAPISimulator::ScenarioAPISimulator(rclcpp::Node::SharedPtr node)
   clock_(node->get_clock())
 {
   /* initializer*/
-  npc_route_manager_ = std::make_shared<NPCRouteManager>();
+  npc_route_manager_ = std::make_shared<NPCRouteManager>(node);
 
   /* register service client*/
   client_ = node->create_client<npc_simulator::srv::GetObject>(

--- a/api/scenario_api_simulator/src/scenario_api_simulator.cpp
+++ b/api/scenario_api_simulator/src/scenario_api_simulator.cpp
@@ -31,7 +31,7 @@ ScenarioAPISimulator::ScenarioAPISimulator(rclcpp::Node::SharedPtr node)
 {
   /* initializer*/
   npc_route_manager_ = std::make_shared<NPCRouteManager>(*node);
-  npc_simulator_ = std::make_shared<NPCSimulatorNode>(*node);
+  npc_simulator_ = std::make_shared<NPCSimulator>(*node);
 
   /* register publisher */
   rclcpp::QoS durable_qos{1};

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -9,18 +9,25 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
+# needs to invoke `find_package` manually to make `ament_auto_find_build_dependencies` available
 find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 
+# we require all dependencies but by default ament_auto_find_build_dependencies doesn't require packages
+ament_auto_find_build_dependencies(REQUIRED
+  ${${PROJECT_NAME}_BUILD_DEPENDS}
+  ${${PROJECT_NAME}_BUILDTOOL_DEPENDS}
+)
+
+###
 # message generation
-
+###
 set(msg_files
   msg/LaneChangeDir.msg
   msg/LaneFollowMode.msg
   msg/Object.msg
 )
 set(service_files
-    srv/GetObject.srv
+  srv/GetObject.srv
 )
 set(msg_dependencies
   autoware_perception_msgs
@@ -36,60 +43,54 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   )
 ament_export_dependencies(rosidl_default_runtime)
 
-# ament_auto_add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
-# target_link_libraries(${PROJECT_NAME}_node "${Boost_LIBRARY_DIR}")
-# ament_target_dependencies(${PROJECT_NAME}_node Boost)
+###
+# create library
+###
 add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
 target_link_libraries(${PROJECT_NAME}_node "${Boost_LIBRARY_DIR}")
-
 target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-  )
-target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BIN_DIR}/rosidl_generator_cpp>
   $<INSTALL_INTERFACE:include>
   )
-ament_target_dependencies(${PROJECT_NAME}_node
-  autoware_lanelet2_msgs
-  autoware_perception_msgs
-  Boost
-  dummy_perception_publisher
-  lanelet2_extension
-  rclcpp
-  sensor_msgs
-  std_msgs
-  tf2
-  tf2_geometry_msgs
-  tf2_ros
-  unique_identifier_msgs
-  vehicle_info_util
-  )
 
-ament_auto_add_executable(${PROJECT_NAME}_main
-  src/main.cpp
+# capitalize the boost dependency
+set(node_deps ${${PROJECT_NAME}_BUILD_DEPENDS})
+list(REMOVE_ITEM node_deps boost)
+list(APPEND node_deps Boost)
+
+ament_target_dependencies(${PROJECT_NAME}_node
+  ${node_deps}
 )
-target_link_libraries(${PROJECT_NAME}_main ${PROJECT_NAME}_node)
 
 # to allow using interfaces created in this package
 rosidl_target_interfaces(${PROJECT_NAME}_node
   ${PROJECT_NAME} "rosidl_typesupport_cpp"
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 # export targets because rosidl automatically exports targets so relying on old-style variables fails in client
 # packages; e.g. the include directories for dependencies of this packages are not taken over. So we cannot use
 # `ament_auto_package()`
 ament_export_targets(export_${PROJECT_NAME}_node HAS_LIBRARY_TARGET)
 
-install(
-  DIRECTORY include/
-  DESTINATION include
+###
+# create executable
+###
+ament_auto_add_executable(${PROJECT_NAME}_main
+  src/main.cpp
 )
+target_link_libraries(${PROJECT_NAME}_main ${PROJECT_NAME}_node)
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# install(
+#   DIRECTORY include/
+#   DESTINATION include
+# )
 
 install(
   TARGETS ${PROJECT_NAME}_node
@@ -100,11 +101,4 @@ install(
   INCLUDES DESTINATION include
 )
 
-# TODO port to ament_package
-# ament_auto_package(
-#   INSTALL_TO_SHARE launch
-# )
-ament_package(
-)
-
-message("targets: ${${PROJECT_NAME}_TARGETS}")
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -37,7 +37,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_auto_add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
-target_include_directories(${PROJECT_NAME}_node PRIVATE "${Boost_INCLUDE_DIR}")
 target_link_libraries(${PROJECT_NAME}_node "${Boost_LIBRARY_DIR}")
 ament_target_dependencies(${PROJECT_NAME}_node Boost)
 

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -89,11 +89,8 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-# install(
-#   DIRECTORY include/
-#   DESTINATION include
-# )
-
+# ament_auto_package() installs headers, libraries, and executables but not the export target so it needs to be done
+# manually
 install(
   TARGETS ${PROJECT_NAME}_node
   EXPORT export_${PROJECT_NAME}_node

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -4,6 +4,8 @@ project(npc_simulator)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -36,13 +36,41 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   )
 ament_export_dependencies(rosidl_default_runtime)
 
-ament_auto_add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
+# ament_auto_add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
+# target_link_libraries(${PROJECT_NAME}_node "${Boost_LIBRARY_DIR}")
+# ament_target_dependencies(${PROJECT_NAME}_node Boost)
+add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
 target_link_libraries(${PROJECT_NAME}_node "${Boost_LIBRARY_DIR}")
-ament_target_dependencies(${PROJECT_NAME}_node Boost)
+
+target_include_directories(${PROJECT_NAME}_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+target_include_directories(${PROJECT_NAME}_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BIN_DIR}/rosidl_generator_cpp>
+  $<INSTALL_INTERFACE:include>
+  )
+ament_target_dependencies(${PROJECT_NAME}_node
+  autoware_lanelet2_msgs
+  autoware_perception_msgs
+  Boost
+  dummy_perception_publisher
+  lanelet2_extension
+  rclcpp
+  sensor_msgs
+  std_msgs
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
+  unique_identifier_msgs
+  vehicle_info_util
+  )
 
 ament_auto_add_executable(${PROJECT_NAME}_main
   src/main.cpp
 )
+target_link_libraries(${PROJECT_NAME}_main ${PROJECT_NAME}_node)
+
 # to allow using interfaces created in this package
 rosidl_target_interfaces(${PROJECT_NAME}_node
   ${PROJECT_NAME} "rosidl_typesupport_cpp"
@@ -53,7 +81,30 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-# export information to downstream packages
-ament_auto_package(
-  INSTALL_TO_SHARE launch
+# export targets because rosidl automatically exports targets so relying on old-style variables fails in client
+# packages; e.g. the include directories for dependencies of this packages are not taken over. So we cannot use
+# `ament_auto_package()`
+ament_export_targets(export_${PROJECT_NAME}_node HAS_LIBRARY_TARGET)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
+
+install(
+  TARGETS ${PROJECT_NAME}_node
+  EXPORT export_${PROJECT_NAME}_node
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+# TODO port to ament_package
+# ament_auto_package(
+#   INSTALL_TO_SHARE launch
+# )
+ament_package(
+)
+
+message("targets: ${${PROJECT_NAME}_TARGETS}")

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -54,7 +54,8 @@ target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BIN_DIR}/rosidl_generator_cpp>
   $<INSTALL_INTERFACE:include>
-  )
+  PRIVATE "${Boost_INCLUDE_DIR}"
+)
 
 # capitalize the boost dependency
 set(node_deps ${${PROJECT_NAME}_BUILD_DEPENDS})

--- a/npc_simulator/include/npc_simulator/node.h
+++ b/npc_simulator/include/npc_simulator/node.h
@@ -192,37 +192,3 @@ public:
     const npc_simulator::srv::GetObject::Request::SharedPtr req,
     const npc_simulator::srv::GetObject::Response::SharedPtr res);
 };
-
-constexpr double normalizeRadianRenamed(
-  const double rad, const double min_rad = -boost::math::constants::pi<double>(),
-  const double max_rad = boost::math::constants::pi<double>())
-{
-  const auto value = std::fmod(rad, 2 * boost::math::constants::pi<double>());
-  if (min_rad < value && value <= max_rad)
-    return value;
-  else
-    return value - std::copysign(2 * boost::math::constants::pi<double>(), value);
-}
-
-inline geometry_msgs::msg::Quaternion getQuatFromYaw(const double yaw)
-{
-  tf2::Quaternion quat;
-  quat.setRPY(0.0, 0.0, yaw);
-  return tf2::toMsg(quat);
-}
-
-inline geometry_msgs::msg::Point toMsg(const lanelet::ConstPoint3d & ll_point)
-{
-  geometry_msgs::msg::Point point;
-  point.x = ll_point.x();
-  point.y = ll_point.y();
-  point.z = ll_point.z();
-  return point;
-}
-
-inline double calcDist2D(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2)
-{
-  const double dx = p1.x - p2.x;
-  const double dy = p1.y - p2.y;
-  return std::hypot(dx, dy);
-}

--- a/npc_simulator/include/npc_simulator/node.h
+++ b/npc_simulator/include/npc_simulator/node.h
@@ -42,7 +42,7 @@
 #include <random>
 #include <tuple>
 
-class NPCSimulatorNode
+class NPCSimulator
 {
 private:
   rclcpp::Logger logger_;
@@ -177,16 +177,16 @@ private:
    *
    * @param duration Time to wait before timer is triggered
    * @param ptr_to_member_fn The timer callback, required to be a pointer to a member function
-   * of NPCSimulatorNode
+   * of NPCSimulator
    *
    * @return the timer
    */
   rclcpp::TimerBase::SharedPtr initTimer(
-    rclcpp::Node& node, const rclcpp::Duration & duration, void (NPCSimulatorNode::*ptr_to_member_fn)(void));
+    rclcpp::Node& node, const rclcpp::Duration & duration, void (NPCSimulator::*ptr_to_member_fn)(void));
 
 public:
-  NPCSimulatorNode(rclcpp::Node& node);
-  ~NPCSimulatorNode(){};
+  NPCSimulator(rclcpp::Node& node);
+  ~NPCSimulator(){};
 
   bool getObject(
     const npc_simulator::srv::GetObject::Request::SharedPtr req,

--- a/npc_simulator/include/npc_simulator/node.h
+++ b/npc_simulator/include/npc_simulator/node.h
@@ -42,9 +42,12 @@
 #include <random>
 #include <tuple>
 
-class NPCSimulatorNode : public rclcpp::Node
+class NPCSimulatorNode
 {
 private:
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+
   rclcpp::Publisher<dummy_perception_publisher::msg::Object>::SharedPtr
     dummy_perception_object_pub_;
   rclcpp::Publisher<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr
@@ -182,10 +185,10 @@ private:
    * @return the timer
    */
   rclcpp::TimerBase::SharedPtr initTimer(
-    const rclcpp::Duration & duration, void (NPCSimulatorNode::*ptr_to_member_fn)(void));
+    rclcpp::Node& node, const rclcpp::Duration & duration, void (NPCSimulatorNode::*ptr_to_member_fn)(void));
 
 public:
-  NPCSimulatorNode();
+  NPCSimulatorNode(rclcpp::Node& node);
   ~NPCSimulatorNode(){};
 };
 

--- a/npc_simulator/include/npc_simulator/node.h
+++ b/npc_simulator/include/npc_simulator/node.h
@@ -127,9 +127,6 @@ private:
   void inputVelocityZ(
     npc_simulator::msg::Object * obj, const double prev_z_pos, const double delta_time);
 
-  bool getObject(
-    const npc_simulator::srv::GetObject::Request::SharedPtr req,
-    const npc_simulator::srv::GetObject::Response::SharedPtr res);
   void engageCallback(const std_msgs::msg::Bool::ConstSharedPtr engage);
   void objectCallback(const npc_simulator::msg::Object::ConstSharedPtr msg);
   void mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg);
@@ -190,9 +187,13 @@ private:
 public:
   NPCSimulatorNode(rclcpp::Node& node);
   ~NPCSimulatorNode(){};
+
+  bool getObject(
+    const npc_simulator::srv::GetObject::Request::SharedPtr req,
+    const npc_simulator::srv::GetObject::Response::SharedPtr res);
 };
 
-constexpr double normalizeRadian(
+constexpr double normalizeRadianRenamed(
   const double rad, const double min_rad = -boost::math::constants::pi<double>(),
   const double max_rad = boost::math::constants::pi<double>())
 {

--- a/npc_simulator/launch/npc_simulator.launch.xml
+++ b/npc_simulator/launch/npc_simulator.launch.xml
@@ -6,7 +6,7 @@
   <arg name="lexus_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.yaml" />
 
   <group ns="simulation">
-    <node pkg="npc_simulator" exec="npc_simulator_node" name="npc_simulator" output="screen">
+    <node pkg="npc_simulator" exec="npc_simulator_main" name="npc_simulator" output="screen">
       <param from="$(var lexus_param_file)" />
       <param name="/initial_engage_state" value="$(var initial_engage_state)"/>
       <remap from="/input/engage" to="npc_simulator/engage"/>

--- a/npc_simulator/package.xml
+++ b/npc_simulator/package.xml
@@ -17,6 +17,7 @@
   <depend>dummy_perception_publisher</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
+  <depend>scenario_api_utils</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>

--- a/npc_simulator/src/main.cpp
+++ b/npc_simulator/src/main.cpp
@@ -22,7 +22,9 @@
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<NPCSimulatorNode>());
+  auto spin_node = std::make_shared<rclcpp::Node>("npc_simulator");
+  auto npc_simulator = std::make_shared<NPCSimulatorNode>(*spin_node);
+  rclcpp::spin(spin_node);
   rclcpp::shutdown();
 
   return 0;

--- a/npc_simulator/src/main.cpp
+++ b/npc_simulator/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto spin_node = std::make_shared<rclcpp::Node>("npc_simulator");
-  auto npc_simulator = std::make_shared<NPCSimulatorNode>(*spin_node);
+  auto npc_simulator = std::make_shared<NPCSimulator>(*spin_node);
   rclcpp::spin(spin_node);
   rclcpp::shutdown();
 

--- a/npc_simulator/src/node.cpp
+++ b/npc_simulator/src/node.cpp
@@ -518,7 +518,7 @@ int NPCSimulatorNode::getCurrentLaneletID(
 
     double current_yaw = tf2::getYaw(obj_pose.orientation);
     double lane_yaw = lanelet::utils::getLaneletAngle(lanelet.second, obj_pose.position);
-    double delta_yaw = std::abs(normalizeRadian(current_yaw - lane_yaw));
+    double delta_yaw = std::abs(normalizeRadianRenamed(current_yaw - lane_yaw));
     auto lanetag = lanelet.second.attributeOr("turn_direction", "else");
     double current_dist =
       lanelet.first + addCostByLaneTag(lane_follow_dir, lanetag, base_cost_by_lane_tag_);
@@ -567,7 +567,7 @@ double NPCSimulatorNode::getCurrentDiffYaw(
   const geometry_msgs::msg::Pose & pose, const double lane_yaw)
 {
   double current_yaw = tf2::getYaw(pose.orientation);
-  return normalizeRadian(lane_yaw - current_yaw);
+  return normalizeRadianRenamed(lane_yaw - current_yaw);
 }
 
 double NPCSimulatorNode::getFootOfPerpendicularLineLength(
@@ -632,7 +632,7 @@ double NPCSimulatorNode::getCurrentLaneDist(
   double diff_y = nearest_y - pose.position.y;
   double current_yaw = tf2::getYaw(pose.orientation);
   double nearest_yaw = atan2(diff_y, diff_x);
-  double diff_yaw = normalizeRadian(nearest_yaw - current_yaw);
+  double diff_yaw = normalizeRadianRenamed(nearest_yaw - current_yaw);
   if (std::abs(diff_yaw) < 10e-04) return 0.0;
   double base_dist = pl_dist_from_center_line * (diff_yaw / std::abs(diff_yaw));
 


### PR DESCRIPTION
# Summary
This directly integrates the NPC simulator into the scenario_api_simulator package. We can thereby eliminate the awkwardness of a service call (see https://github.com/tier4/planning_simulator.iv.universe/pull/5#discussion_r522297262) and simply call the `getObject()` function on the object directly. This assumes no other nodes use the npc_simulator service.

# Changes in this PR
* Fixed a lot of unused and missing headers and packages.
* `ament_uncrustify` – that was a mistake since it makes the diff much larger. Sorry about this.
* Made `NPCRouteManager` (in this package) and `NPCSimulatorNode` (in its own package) an extension node – it receives a `rclcpp::Node&` in the constructor and extracts a logger and clock that it stores
* Same for the main node, `ScenarioAPISimulator`, except it receives an `rclcpp::Node::SharedPtr` for consistency with [`scenario_api_autoware`](https://github.com/tier4/scenario_runner.iv.universe/pull/12)
* Removed pointless `ros::spinOnce();` in timer callback – the node was already spinning, just before the timer callback.
* Changes to the `npc_simulator` build by @fred-apex-ai to ensure that transitive build dependencies (like `vehicle_info_util`) work correctly
* Made `npc_simulator::getObject` public and make `scenario_api_simulator` call it directly.
* Fixed name collision for `normalizeRadian` between `scenario_api_utils` and `npc_simulator`, and reduced the risk of further collisions by making `toMsg` and `calcDist2D` helper functions have internal linkage.

# TODOs for future PRs
* Do not use `std_msgs`
* We can remove the service in the NPC simulator if we go with this.
* Maybe move the `npc_simulator` into this package since it is now invalid to run it outside of this node