### PR TITLE
Add scenario_runner to build_depends.repos

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/tier4/pilot.auto.git
     version: ros2
+  simulator/scenario_runner:
+    type: git
+    url: https://github.com/tier4/scenario_runner.iv.universe.git
+    version: ros2
   description/vehicle/lexus_description:
     type: git
     url: https://github.com/tier4/lexus_description.iv.universe.git


### PR DESCRIPTION
For `scenario_api_utils`, see https://github.com/tier4/planning_simulator.iv.universe/pull/8/checks?check_run_id=1405850934