### PR TITLE
Build npc_simulator and scenario_api_simulator as shared objects

### DIFF
--- a/api/scenario_api_simulator/CMakeLists.txt
+++ b/api/scenario_api_simulator/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-ament_auto_add_library(${PROJECT_NAME}
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/scenario_api_simulator.cpp
   src/npc_route_manager.cpp
   )

--- a/npc_simulator/CMakeLists.txt
+++ b/npc_simulator/CMakeLists.txt
@@ -48,7 +48,7 @@ ament_export_dependencies(rosidl_default_runtime)
 ###
 # create library
 ###
-add_library(${PROJECT_NAME}_node STATIC src/node.cpp)
+add_library(${PROJECT_NAME}_node SHARED src/node.cpp)
 target_link_libraries(${PROJECT_NAME}_node "${Boost_LIBRARY_DIR}")
 target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
In consuming `npc_simulator` and `scenario_api_simulator` from `scenario_api` in https://github.com/tier4/scenario_runner.iv.universe/pull/11, I had this linker error that I couldn't fix otherwise. 

```
/usr/bin/ld: /__w/scenario_runner.iv.universe/scenario_runner.iv.universe/install/scenario_api_autoware/lib/libscenario_api_autoware.so: undefined reference to symbol '_ZN22rosidl_typesupport_cpp31get_message_type_support_handleIN22autoware_lanelet2_msgs3msg7MapBin_ISaIvEEEEEPK29rosidl_message_type_support_tv'
/usr/bin/ld: /__w/scenario_runner.iv.universe/scenario_runner.iv.universe/install/autoware_lanelet2_msgs/lib/libautoware_lanelet2_msgs__rosidl_typesupport_cpp.so: error adding symbols: DSO missing from command line
```

I tried a lot of things and can provide more details if you like. 
I'm glad I found this solution, it blocks the CI in https://github.com/tier4/scenario_runner.iv.universe/pull/11 so let's merge this fast and first @mitsudome-r @esteve 

I have spent so many hours in the last days with linker errors. Either we just don't get it right to define the dependencies in ament, or ament is just broken if you use static libraries (the default!). To save us from further trouble, we should create shared objects by default